### PR TITLE
[codex] Allow Cast provider manifest replacement

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-<!--    // merge config for pip supportsPictureInPicture -->
-<!--    <application android:supportsPictureInPicture="true" />-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!-- merge config for pip supportsPictureInPicture -->
+    <!-- <application android:supportsPictureInPicture="true" /> -->
     <application>
-            <meta-data
-            android:name=
-                "com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-            android:value="ee.forgr.ivsplayer.CastOptionsProvider" />
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="ee.forgr.ivsplayer.CastOptionsProvider"
+            tools:replace="android:value" />
     </application>
 </manifest>


### PR DESCRIPTION
## What
- Add `tools:replace="android:value"` to the Android Cast provider metadata.
- Normalize the IVS Android manifest formatting around the Cast metadata.

## Why
- Apps that install multiple Cast-enabled plugins can fail Android manifest merge because Google Cast allows one `OPTIONS_PROVIDER_CLASS_NAME` metadata value per app.

## How
- Keep the existing IVS Cast provider.
- Allow the manifest merger to replace another Cast provider value instead of failing on duplicate metadata.

## Testing
- Ran `xmllint --noout android/src/main/AndroidManifest.xml`.
- Tried `bun run verify:android`.

## Not Tested
- `bun run verify:android` could not complete locally because the machine has no system Java runtime available; using Android Studio JBR also failed before Gradle produced build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to improve compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->